### PR TITLE
red-to-pipe and tokenizer fix

### DIFF
--- a/builtins/echo.c
+++ b/builtins/echo.c
@@ -62,7 +62,7 @@ void	echo(char **command, t_token *token_lst, int fd_in, int fd_out)
 		return ;
 	if (pid == 0)
 	{
-		dup_bult_in(token_lst, fd_in, fd_out);
+		dup_info(token_lst, fd_in, fd_out);
 		echo_output(command, i, no_newline);
 		exit(0);
 	}

--- a/builtins/env.c
+++ b/builtins/env.c
@@ -68,7 +68,7 @@ void	env(t_token *token_lst, int fd_in, int fd_out)
 		return ;
 	if (pid == 0)
 	{
-		dup_bult_in(token_lst, fd_in, fd_out);
+		dup_info(token_lst, fd_in, fd_out);
 		temp = info()->env;
 		while (temp)
 		{

--- a/builtins/export.c
+++ b/builtins/export.c
@@ -23,7 +23,7 @@ void	export(char **command, t_token *token_lst, int fd_in, int fd_out)
 			return ;
 		if (pid == 0)
 		{
-			dup_bult_in(token_lst, fd_in, fd_out);
+			dup_info(token_lst, fd_in, fd_out);
 			print_export(0, NULL);
 			exit(0);
 		}

--- a/builtins/pwd.c
+++ b/builtins/pwd.c
@@ -26,7 +26,7 @@ void	pwd(char **command, t_token *token_lst, int fd_in, int fd_out)
 			perror("minishell");
 		else if (pid == 0)
 		{
-			dup_bult_in(token_lst, fd_in, fd_out);
+			dup_info(token_lst, fd_in, fd_out);
 			path = getcwd(NULL, 0);
 			if (path != NULL)
 			{

--- a/execution.c
+++ b/execution.c
@@ -20,6 +20,7 @@ void	run(char **cmd, char *command)
 	env_list = create_env_list();
 	res = execve(command, cmd, env_list);
 	free_env_list(env_list);
+	signal(SIGINT, SIG_DFL);
 	if (res == -1)
 	{
 		if (access(command, F_OK) == 0)
@@ -54,14 +55,12 @@ char	*check_executable(char *cmd)
 	return (NULL);
 }
 
-// flag -> red_in = 0 | red_out - 1
-void	execute_redirection(t_token *token_lst, char **cmd, int fd_in, int fd_out)
+void	execute(t_token *token_lst, char **cmd, int fd_in, int fd_out)
 {
 	char	*command;
 	int	pid;
 	bool	blt_in;
 
-	info()->fd_red = TRUE;
 	blt_in = is_builtin(cmd, token_lst, fd_in, fd_out);
 	if (!blt_in)
 	{
@@ -76,61 +75,10 @@ void	execute_redirection(t_token *token_lst, char **cmd, int fd_in, int fd_out)
 			return ;
 		if (pid == 0)
 		{
-			if (info()->in_flag == TRUE)
-				dup2(fd_in, STDIN_FILENO);
-			if (info()->out_flag == TRUE)
-				dup2(fd_out, STDOUT_FILENO);
+			dup_info(token_lst, fd_in, fd_out);
 			run(cmd, command);
 		}
 		free(command);
 	}
-	info()->fd_red = FALSE;
 }
 
-void	execute(t_token *token_lst, char **cmd, char *command)
-{
-	int	j;
-
-	j = -1;
-	if (info()->cmd_nr == 0 && !token_lst->next)
-		run(cmd, command);
-	else
-	{
-		if (info()->cmd_nr != 0)
-			dup2(info()->fd_pipe[info()->cmd_nr - 1][0], STDIN_FILENO);
-		if (token_lst->next)
-			dup2(info()->fd_pipe[info()->cmd_nr][1], STDOUT_FILENO);
-		while (++j < info()->nr_pipe)
-		{
-			close(info()->fd_pipe[j][0]);
-			close(info()->fd_pipe[j][1]);
-		}
-		run(cmd, command);
-	}
-}
-
-// fd[0] - read
-// fd[1] - write
-void	execute_simple_cmd(t_token *token_lst, char **cmd)
-{
-	char	*command;
-	int		pid;
-	bool	blt_in;
-
-	blt_in = is_builtin(cmd, token_lst, 0, 0);
-	if (!blt_in)
-	{
-		command = check_executable(cmd[0]);
-		if (!command)
-		{
-			free(command);
-			return ;
-		}
-		pid = fork();
-		if (pid == -1)
-			return ;
-		if (pid == 0)
-				execute(token_lst, cmd, command);
-		free(command);
-	}
-}

--- a/get_token.c
+++ b/get_token.c
@@ -31,19 +31,28 @@ void	free_matrix(char **matrix)
 int	qt_len(char *str, int i)
 {
 	int	len;
+	int	qt;
 
 	len = 0;
-	if (str[i] == '"')
+	qt = 0;
+	while (str[i] && (str[i] == '"' || str[i] == 39))
 	{
-		while (str[++i] != '"')
-			len++;
+		qt++;
+		len++;
+		i++;
 	}
-	else if (str[i] == 39)
+	while (str[i] && qt != 0)
 	{
-		while (str[++i] != 39)
-			len++;
+		len++;
+		if (str[i] == '"' || str[i] == 39)
+		{
+			qt--;
+			if (qt == 0 && str[i + 1] != 32 && str[i + 1] != '\0')
+				qt++;
+		}
+		i++;
 	}
-	return (len + 2);
+	return (len);
 }
 
 int	token_len(char *str, int i)
@@ -59,9 +68,7 @@ int	token_len(char *str, int i)
 	}
 	while (str[i] && !(str[i] >= 9 && str[i] <= 13) && str[i] != 32)
 	{
-		if (str[i] == '"')
-			return (qt_len(str, i));
-		else if (str[i] == 39)
+		if (str[i] == '"' || str[i] == 39)
 			return (qt_len(str, i));
 		if (str[i] == '|' || str[i] == '>' || str[i] == '<')
 			return (len);

--- a/minishell.c
+++ b/minishell.c
@@ -15,11 +15,20 @@
 // changes Ctrl+C to \n
 void	sig_handler(int n)
 {
+	pid_t	pid;
+	int		status;
+
 	(void)n;
-	write(1, "\n", 1);
-	rl_replace_line("", 0);
-	rl_on_new_line();
-	rl_redisplay();
+	pid = waitpid(-1, &status, 0);
+	if (pid == -1)
+	{
+		write(1, "\n", 1);
+		rl_replace_line("", 0);
+		rl_on_new_line();
+		rl_redisplay();
+	}
+	else
+		write(1, "\n", 1);
 }
 
 void	ignore_signal(void)

--- a/minishell.h
+++ b/minishell.h
@@ -114,9 +114,7 @@ void	heredocs();
 // execution.c
 void	run(char **cmd, char *command);
 char	*check_executable(char	*cmd);
-void	execute(t_token *token_lst, char **cmd, char *command);
-void	execute_simple_cmd(t_token *token_lst, char **cmd);
-void	execute_redirection(t_token *token_lst, char **cmd, int fd_in, int fd_out);
+void	execute(t_token *token_lst, char **cmd, int fd_in, int fd_out);
 
 // expansions.c
 void	cpy_var_value(char *new_str, char *old_str, int *i, int *k);
@@ -134,11 +132,10 @@ bool	is_expansion(char *str);
 int		quotes_end(char *str, int i);
 char	*ft_strjoin_nl(char *s1, char *s2);
 void	cpy_command(t_token **token_lst, int i);
-void	cpy_operator(t_token **token_lst, int i);
 void	free_fd(int	**fd);
 
 // utils2.c
-void	dup_bult_in(t_token *token_lst, int fd_in, int fd_out);
+void	dup_info(t_token *token_lst, int fd_in, int fd_out);
 char    **get_cmd_red_matrix(char **cmd_red, int j);
 int get_cmd_red_len(char **cmd_red);
 int	**get_pipe_fd(void);
@@ -147,7 +144,7 @@ bool	check_pipe(t_token *token_lst);
 // red_utils.c
 char	*get_dir_path(char *cmd);
 int	open_file(char *file, int flag);
-int	check_if_invalid(char **cmd);
+int	check_invalid_red(char **cmd);
 
 // struct_utils.c
 void	add_back(t_token **token_list, t_token *new);

--- a/parser.c
+++ b/parser.c
@@ -135,7 +135,6 @@ int	get_fd_out(char **cmd_red)
 	return (fd);
 }
 
-//dont forget to handlde >< and <>
 void	parse_redirection(t_token *token_lst, char **cmd)
 {
 	int	fd_in;
@@ -148,15 +147,11 @@ void	parse_redirection(t_token *token_lst, char **cmd)
 	if (info()->file_flag == 2)
 		return ;
 	cmd_matrix = get_cmd_red_matrix(cmd, 0);
-	if (fd_in != -1)
-		info()->in_flag = TRUE;
-	if (fd_out != -1)
-		info()->out_flag = TRUE;
 	if (cmd_matrix[0])
-		execute_redirection(token_lst, cmd_matrix, fd_in, fd_out);
-	wait(NULL);
+		execute(token_lst, cmd_matrix, fd_in, fd_out);
 	close(fd_in);
 	close(fd_out);
+	wait(NULL);
 	free_matrix(cmd_matrix);
 }
 
@@ -164,9 +159,6 @@ void	check_command_type(t_token *token_lst, char **cmd)
 {
 	int	i;
 
-	info()->in_flag = FALSE;
-	info()->out_flag = FALSE;
-	info()->fd_red = FALSE;
 	i = 0;
 	while (cmd[i])
 	{
@@ -177,7 +169,7 @@ void	check_command_type(t_token *token_lst, char **cmd)
 	if (cmd[i])
 		parse_redirection(token_lst, cmd);
 	else
-		execute_simple_cmd(token_lst, cmd);
+		execute(token_lst, cmd, 0, 0);
 }
 
 void	parse_commands(t_token *token_lst)
@@ -188,7 +180,7 @@ void	parse_commands(t_token *token_lst)
 	info()->fd_pipe = get_pipe_fd();
 	while (token_lst)
 	{
-		if (check_if_invalid(token_lst->value))
+		if (check_invalid_red(token_lst->value))
 			break ;
 		if (ft_strcmp(token_lst->type, "Command") == 0)
 		{

--- a/red_utils.c
+++ b/red_utils.c
@@ -32,7 +32,7 @@ int	open_file(char *file, int flag)
 	return (fd);
 }
 
-int	check_if_invalid(char **cmd)
+int	check_invalid_red(char **cmd)
 {
 	int	i;
 

--- a/utils.c
+++ b/utils.c
@@ -55,19 +55,25 @@ void	cpy_command(t_token **token_lst, int i)
 
 int	quotes_end(char *str, int i)
 {
-	if (str[i] == '"')
+	int	qt;
+
+	qt = 0;
+	while (str[i] && (str[i] == '"' || str[i] == 39))
 	{
+		qt++;
 		i++;
-		while (str[i] && str[i] != '"')
-			i++;
 	}
-	else if (str[i] == 39)
+	while (str[i] && qt != 0)
 	{
+		if (str[i] == '"' || str[i] == 39)
+		{
+			qt--;
+			if (qt == 0 && str[i + 1] != 32 && str[i + 1] != '\0')
+				qt++;
+		}
 		i++;
-		while (str[i] && str[i] != 39)
-			i++;
 	}
-	return (i);
+	return (i - 1);
 }
 
 char	*ft_strjoin_nl(char *s1, char *s2)

--- a/utils2.c
+++ b/utils2.c
@@ -17,29 +17,39 @@ bool	check_pipe(t_token *token_lst)
 	return (false);
 }
 
-void	dup_bult_in(t_token *token_lst, int fd_in, int fd_out)
+// fd[0] - read
+// fd[1] - write
+void	dup_info(t_token *token_lst, int fd_in, int fd_out)
 {
 	int	j;
 
-	if (info()->fd_red == TRUE)
+	if (fd_in > 0)
 	{
-		if (info()->in_flag == TRUE)
-			dup2(fd_in, STDIN_FILENO);
-		if (info()->out_flag == TRUE)
-			dup2(fd_out, STDOUT_FILENO);
+		//printf("cmd_nr - %d | fd_in - %d | fd_out - %d ||| dup_fd_in -- 1\n", info()->cmd_nr, fd_in, fd_out);
+		dup2(fd_in, STDIN_FILENO);
+		close(fd_in);
 	}
-	else
+	if (info()->cmd_nr != 0)
 	{
-		if (info()->cmd_nr != 0)
-			dup2(info()->fd_pipe[info()->cmd_nr - 1][0], STDIN_FILENO);
-		if (token_lst->next)
-			dup2(info()->fd_pipe[info()->cmd_nr][1], STDOUT_FILENO);
-		j = -1;
-		while (++j < info()->nr_pipe)
-		{
-			close(info()->fd_pipe[j][0]);
-			close(info()->fd_pipe[j][1]);
-		}
+		//printf("cmd_nr - %d | fd_in - %d | fd_out - %d ||| dup_pipe_in -- 3\n", info()->cmd_nr, fd_in, fd_out);
+		dup2(info()->fd_pipe[info()->cmd_nr - 1][0], STDIN_FILENO);
+	}
+	if (fd_out > 0)
+	{
+		//printf("cmd_nr - %d | fd_in - %d | fd_out - %d ||| dup_fd_out -- 2\n", info()->cmd_nr, fd_in, fd_out);
+		dup2(fd_out, STDOUT_FILENO);
+		close(fd_out);
+	}
+	if (token_lst->next)
+	{
+		//printf("cmd_nr - %d | fd_in - %d | fd_out - %d ||| dup_pipe_out -- 4\n", info()->cmd_nr, fd_in, fd_out);
+		dup2(info()->fd_pipe[info()->cmd_nr][1], STDOUT_FILENO);
+	}	
+	j = -1;
+	while (++j < info()->nr_pipe)
+	{
+		close(info()->fd_pipe[j][0]);
+		close(info()->fd_pipe[j][1]);
 	}
 }
 


### PR DESCRIPTION
dup redirections to pipe
tokenizer fix quotes
ctrl - d fix when child process